### PR TITLE
Fix network link in google_container_cluster resource

### DIFF
--- a/example-gke-k8s-service-lb/main.tf
+++ b/example-gke-k8s-service-lb/main.tf
@@ -38,7 +38,7 @@ resource "google_container_cluster" "default" {
   zone               = "${var.zone}"
   initial_node_count = 3
   min_master_version = "${data.google_container_engine_versions.default.latest_master_version}"
-  network            = "${google_compute_subnetwork.default.name}"
+  network            = "${google_compute_network.default.name}"
   subnetwork         = "${google_compute_subnetwork.default.name}"
 
   // Use legacy ABAC until these issues are resolved: 


### PR DESCRIPTION
Change from google_compute_subnetwork.default.name to google_compute_network.default.name even though they have the same name (var.network_name).